### PR TITLE
Fix std::chrono errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
 #include <map>
 #include <sstream>
 #include <vector>
+#include <algorithm>
+#include <chrono>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>


### PR DESCRIPTION
algorithm and chrono headers need to be included in the main.cpp file to fix std::chrono errors on Linux.

Just in case, please test if it builds fine on other environments.