### PR TITLE
Ability to play past puzzles

### DIFF
--- a/src/index-tmpl.html
+++ b/src/index-tmpl.html
@@ -81,10 +81,10 @@
                 updateWindowSize();
 
                 if (Module.get_puzzle_id() >= 0) {
-                  var dataAttempts = Module.get_attempts();
-                  if (dataAttempts.length > 0) {
-                      localStorage["attempts_" + Module.get_puzzle_id()] = dataAttempts;
-                  }
+                    var dataAttempts = Module.get_attempts();
+                    if (dataAttempts.length > 0) {
+                        localStorage["attempts_" + Module.get_puzzle_id()] = dataAttempts;
+                    }
                 }
 
                 var dataStatistics = Module.get_statistics();

--- a/src/index-tmpl.html
+++ b/src/index-tmpl.html
@@ -80,9 +80,11 @@
 
                 updateWindowSize();
 
-                var dataAttempts = Module.get_attempts();
-                if (dataAttempts.length > 0) {
-                    localStorage.attempts = dataAttempts;
+                if (Module.get_puzzle_id() >= 0) {
+                  var dataAttempts = Module.get_attempts();
+                  if (dataAttempts.length > 0) {
+                      localStorage["attempts_" + Module.get_puzzle_id()] = dataAttempts;
+                  }
                 }
 
                 var dataStatistics = Module.get_statistics();
@@ -187,8 +189,27 @@
                         Module.set_timestamp(T);
                     }
 
-                    if (localStorage.getItem('attempts') !== null) {
-                        Module.set_attempts(localStorage.attempts);
+                    if (Module.do_puzzle_init() == false) {
+                        failedToInitialize = true;
+                        window.onerror('Failed to initialize initial puzzle!');
+                        return;
+                    }
+
+                    // Get puzzle attempts
+                    let attemptsKeys = Object.keys(localStorage).filter(key => key.startsWith("attempts_"));
+                    for (const key of attemptsKeys) {
+                        const keySplit = key.split('_');
+                        if (keySplit[1].length == 0) {
+                            localStorage.removeItem(key);
+                            continue;
+                        }
+                        const puzzleID = Number(keySplit[1]);
+                        if (puzzleID == NaN || puzzleID < 0) {
+                            localStorage.removeItem(key);
+                            continue;
+                        }
+
+                        Module.set_attempts(puzzleID, localStorage[key]);
                     }
 
                     if (localStorage.getItem('statistics') !== null) {
@@ -199,9 +220,9 @@
                         Module.set_settings(localStorage.settings);
                     }
 
-                    if (Module.do_init() == false) {
+                    if (Module.do_game_init() == false) {
                         failedToInitialize = true;
-                        window.onerror('Failed to initialize WASM module');
+                        window.onerror('Failed to initialize game state!');
                         return;
                     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -546,12 +546,6 @@ struct State {
 
             // the daily pool list is already randomized:
             puzzle->answer = wordsDailyPool[puzzle->id % wordsDailyPool.size()];
-
-            // workaround for latin letter in word ПРЯКА
-            // ref: https://github.com/ggerganov/wordle-bg/issues/8
-            // if (puzzleId == 643) {
-            //    puzzle->answer = "ПРЯКА";
-            //}
         }
 
         // Initialize grid


### PR DESCRIPTION
Logic and a GUI have been added to allow selecting past puzzles (with past words as answers), based on ID.

![Past puzzles popup window with selector](https://github.com/ggerganov/wordle-bg/assets/78196474/5f5a2b03-5e5f-4d89-8cfb-ca512ea92398)

Past puzzles are not counted towards statistics. Their data can be loaded from/saved to `localStorage` by the JS layer.

Personally, I see the ability to play past puzzles being really beneficial in certain cases:

* They give players a way to practice more extensively.
* They allow a player to compete with others on a past puzzle, despite having missed it.
* They allow a player to solve a past puzzle, if they wish to keep up with the game daily.

In the popup window, holding the arrows with the left mouse button, or holding the respective arrow key on the keyboard allow for moving quickly through IDs.

**Additionally:**

* If a daily pool word list is missing, the chosen word is now truly random - `srand` is provided the current timestamp.
* Game input is no longer detected, when a popup window is active.
* Mutual properties and `visible(float T)` function between popup windows are now inherited from a base struct.
* The workaround for the issue with the word "пряка", added in 4efdde746a6343f8a25db2a1b1cfa8fa361e4fa8, was commented out. Perhaps it can be applied to the hidden daily pool list, avoiding hardcoding? If not, I will uncomment it. 