### PR TITLE
Restrict share dialog to mobile devices only

### DIFF
--- a/src/index-tmpl.html
+++ b/src/index-tmpl.html
@@ -119,7 +119,10 @@
                 var dataClipboard = Module.get_clipboard();
                 if (dataClipboard.length > 0) {
                     console.log(dataClipboard);
-                    if (navigator.share) {
+
+                    // Restrict share dialog to mobile devices only, since desktop OS-es tend to not feature copying to clipboard
+                    // See: https://github.com/ggerganov/wordle-bg/issues/11
+                    if (navigator.share && isMobile) {
                         navigator.share({
                                         title: document.title,
                                         text: dataClipboard


### PR DESCRIPTION
Restricts the share dialog to mobile devices only, since desktop OS-es tend to not feature copying to clipboard. Uses the existing `isMobile` variable to perform the check.

The code being used for the `mobileCheck()` function, which is what `isMobile` is set to, [seems to originate from](https://stackoverflow.com/a/11381730) [detectmobilebrowsers.com](https://detectmobilebrowsers.com), so I tested that website on my PC (in Chrome) and my phone, and the detection worked as it should.

Fixes #11.