### PR TITLE
Fix no "Results copied to clipboard" text on PC

### DIFF
--- a/src/index-tmpl.html
+++ b/src/index-tmpl.html
@@ -168,7 +168,7 @@
             function init() {
                 // If sharing is supported, hide the "Results copied to clipboard" text by default.
                 // The text will be shown only if sharing fails.
-                if (navigator.share) {
+                if (navigator.share && isMobile) {
                     Module.set_clipboard_text_visible(false);
                 }
 


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/ggerganov/wordle-bg/issues/11#issuecomment-2079725580), the "Results copied to clipboard" text doesn't show on PC in browsers, which support share dialogs, but have been disabled due to the check, added in #12.

I forgot to do this in the aforementioned PR.